### PR TITLE
made bg of about us page different from navbar FIX #171

### DIFF
--- a/Frontend/aboutUs/aboutus.css
+++ b/Frontend/aboutUs/aboutus.css
@@ -70,7 +70,7 @@
         padding: 120px 0;
         position: relative;
         overflow: hidden;
-        background-image: linear-gradient(to right, #0e162b, #2a2a48, #0e162b);
+        background: #0A101F;
     }
     
     .about-container {


### PR DESCRIPTION
ok, made bg of about us page different from navbar
I have made it's bg same as that of home page
![Screenshot (412)](https://github.com/user-attachments/assets/cca8ac73-e22c-4bc0-833c-c2a585f420b3)
